### PR TITLE
Adding Scaffolding for Pairing Bot Weekly Checkins

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -78,6 +79,13 @@ type zulipStreamMessage struct {
 }
 
 func (zsm *zulipStreamMessage) postToTopic(ctx context.Context, botPassword, message string, stream string, topic string) error {
+	appEnv := os.Getenv("APP_ENV")
+
+	if appEnv != "production" {
+		log.Println("In the Prod environment Pairing Bot would have posted the following message: ", message)
+		return nil
+	}
+
 	zulipClient := &http.Client{}
 	messageRequest := url.Values{}
 

--- a/client.go
+++ b/client.go
@@ -49,6 +49,7 @@ type userRequest interface {
 	validateAuthCreds(tokenFromDB string) bool
 	validateInteractionType() *botResponse
 	ignoreInteractionType() *botNoResponse
+	getCommandString() string
 	sanitizeUserInput() (string, []string, error)
 	extractUserData() *UserDataFromJSON // does this need an error return value? anything that hasn't been validated previously?
 }
@@ -184,6 +185,10 @@ func (zur *zulipUserRequest) ignoreInteractionType() *botNoResponse {
 
 func (zur *zulipUserRequest) sanitizeUserInput() (string, []string, error) {
 	return parseCmd(zur.json.Data)
+}
+
+func (zur *zulipUserRequest) getCommandString() string {
+	return zur.json.Data
 }
 
 func (zur *zulipUserRequest) extractUserData() *UserDataFromJSON {

--- a/cron.yaml
+++ b/cron.yaml
@@ -10,4 +10,4 @@ cron:
   schedule: every tuesday 18:00
 - description: "Post a weekly checkin for pairing bot to increase :pear: :bot: awareness at RC"
   url: /checkin
-  schedule: every 99999 hours
+  schedule: every thursday 18:00

--- a/cron.yaml
+++ b/cron.yaml
@@ -2,9 +2,12 @@ cron:
 - description: "Daily match-making job"
   url: /match
   schedule: every day 04:00
-- description: "End-of-batch offboarding job that only runs manually"
+- description: "End-of-batch offboarding job that runs weekly"
   url: /endofbatch
   schedule: every saturday 16:00
 - description: "Start of batch (during the 2nd week) message to welcome people to pairing bot"
   url: /welcome
   schedule: every tuesday 18:00
+- description: "Post a weekly checkin for pairing bot to increase :pear: :bot: awareness at RC"
+  url: /checkin
+  schedule: every 99999 hours

--- a/database.go
+++ b/database.go
@@ -331,25 +331,25 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 	return totalPairings, nil
 }
 
-type Feedback struct {
+type Review struct {
 	content   string
 	email     string
 	timestamp int
 }
 
-type FeedbackDB interface {
-	GetAll(ctx context.Context) ([]Feedback, error)
-	GetRandom(ctx context.Context) (Feedback, error)
-	Insert(ctx context.Context, feedback Feedback) error
+type ReviewDB interface {
+	GetAll(ctx context.Context) ([]Review, error)
+	GetRandom(ctx context.Context) (Review, error)
+	Insert(ctx context.Context, review Review) error
 }
 
-// implements RecurserDB
-type FirestoreFeedbackDB struct {
+// implements ReviewDB
+type FirestoreReviewDB struct {
 	client *firestore.Client
 }
 
-func (f *FirestoreFeedbackDB) GetAll(ctx context.Context) ([]Feedback, error) {
-	var allFeedback []Feedback
+func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
+	var allReviews []Review
 
 	iter := f.client.Collection("pairings").Documents(ctx)
 	for {
@@ -361,30 +361,30 @@ func (f *FirestoreFeedbackDB) GetAll(ctx context.Context) ([]Feedback, error) {
 			return nil, err
 		}
 
-		currentFeedback := Feedback{
+		currentReview := Review{
 			content:   doc.Data()["content"].(string),
 			email:     doc.Data()["email"].(string),
 			timestamp: int(doc.Data()["timestamp"].(int64)),
 		}
 
-		allFeedback = append(allFeedback, currentFeedback)
+		allReviews = append(allReviews, currentReview)
 	}
 
-	return allFeedback, nil
+	return allReviews, nil
 }
 
-func (f *FirestoreFeedbackDB) GetRandomFeedback(ctx context.Context) (Feedback, error) {
-	allFeedback, err := f.GetAll(ctx)
+func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
+	allReviews, err := f.GetAll(ctx)
 
 	if err != nil {
-		return Feedback{}, err
+		return Review{}, err
 	}
 
 	rand.Seed(time.Now().Unix())
 
-	return allFeedback[rand.Intn(len(allFeedback))], nil
+	return allReviews[rand.Intn(len(allReviews))], nil
 }
 
-func (f *FirestoreFeedbackDB) Insert(ctx context.Context, feedback Feedback) error {
+func (f *FirestoreReviewDB) Insert(ctx context.Context, review Review) error {
 	return nil
 }

--- a/database.go
+++ b/database.go
@@ -282,7 +282,7 @@ func (f *MockAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, er
 }
 
 type PairingsDB interface {
-	SetKey(ctx context.Context, col string, doc string) error
+	SetKey(ctx context.Context, col string, doc string, value int) error
 	GetKey(ctx context.Context, col string, doc string) (int, error)
 	SetNumPairings(ctx context.Context, day string, numPairings int) error
 	GetTotalPairingsDuringLastWeek(ctx context.Context) (int, error)

--- a/database.go
+++ b/database.go
@@ -386,5 +386,10 @@ func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
 }
 
 func (f *FirestoreReviewDB) Insert(ctx context.Context, review Review) error {
-	return nil
+	_, _, err := f.client.Collection("reviews").Add(ctx, map[string]interface{}{
+		"content":   review.content,
+		"email":     review.email,
+		"timestamp": review.timestamp,
+	})
+	return err
 }

--- a/database.go
+++ b/database.go
@@ -351,7 +351,7 @@ type FirestoreReviewDB struct {
 func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
 	var allReviews []Review
 
-	iter := f.client.Collection("pairings").Documents(ctx)
+	iter := f.client.Collection("reviews").Documents(ctx)
 	for {
 		doc, err := iter.Next()
 		if err == iterator.Done {

--- a/database.go
+++ b/database.go
@@ -328,9 +328,7 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 			return 0, err
 		}
 
-		log.Println("This is the value of the current document", doc.Data()["value"])
-
-		dailyPairings := doc.Data()["value"].(int)
+		dailyPairings := int(doc.Data()["value"].(int64))
 
 		totalPairings += dailyPairings
 	}

--- a/database.go
+++ b/database.go
@@ -328,6 +328,8 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 			return 0, err
 		}
 
+		log.Println("This is the value of the current document", doc.Data()["value"])
+
 		dailyPairings := doc.Data()["value"].(int)
 
 		totalPairings += dailyPairings

--- a/database.go
+++ b/database.go
@@ -333,7 +333,7 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 		totalPairings += dailyPairings
 	}
 
-	log.Println(totalPairings)
+	log.Println("Total number of pairings: ", totalPairings)
 
 	return totalPairings, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -169,6 +169,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
 	case "review":
 		reviewContent := cmdArgs[0]
+
 		currentTimestamp := time.Now().Unix()
 
 		err = pl.revdb.Insert(ctx, Review{

--- a/dispatch.go
+++ b/dispatch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 )
 
 const helpMessage string = "**How to use Pairing Bot:**\n* `subscribe` to start getting matched with other Pairing Bot users for pair programming\n* `schedule monday wednesday friday` to set your weekly pairing schedule\n  * In this example, I've been set to find pairing partners for you on every Monday, Wednesday, and Friday\n  * You can schedule pairing for any combination of days in the week\n* `skip tomorrow` to skip pairing tomorrow\n  * This is valid until matches go out at 04:00 UTC\n* `unskip tomorrow` to undo skipping tomorrow\n* `status` to show your current schedule, skip status, and name\n* `unsubscribe` to stop getting matched entirely\n\nIf you've found a bug, please [submit an issue on github](https://github.com/thwidge/pairing-bot/issues)!"
@@ -166,7 +167,23 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		}
 
 		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
+	case "review":
+		reviewContent := cmdArgs[0]
+		currentTimestamp := time.Now().Unix()
 
+		err = pl.revdb.Insert(ctx, Review{
+			content:   reviewContent,
+			timestamp: int(currentTimestamp),
+			email:     userEmail,
+		})
+
+		if err != nil {
+			log.Println("Encountered an error when trying to save a review: ", err)
+			response = writeErrorMessage
+			break
+		}
+
+		response = "Thank you for sharing your review with pairing bot!"
 	case "help":
 		response = helpMessage
 	default:

--- a/dispatch.go
+++ b/dispatch.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const helpMessage string = "**How to use Pairing Bot:**\n* `subscribe` to start getting matched with other Pairing Bot users for pair programming\n* `schedule monday wednesday friday` to set your weekly pairing schedule\n  * In this example, I've been set to find pairing partners for you on every Monday, Wednesday, and Friday\n  * You can schedule pairing for any combination of days in the week\n* `skip tomorrow` to skip pairing tomorrow\n  * This is valid until matches go out at 04:00 UTC\n* `unskip tomorrow` to undo skipping tomorrow\n* `status` to show your current schedule, skip status, and name\n* `unsubscribe` to stop getting matched entirely\n\nIf you've found a bug, please [submit an issue on github](https://github.com/thwidge/pairing-bot/issues)!"
+const helpMessage string = "**How to use Pairing Bot:**\n* `subscribe` to start getting matched with other Pairing Bot users for pair programming\n* `schedule monday wednesday friday` to set your weekly pairing schedule\n  * In this example, I've been set to find pairing partners for you on every Monday, Wednesday, and Friday\n  * You can schedule pairing for any combination of days in the week\n* `skip tomorrow` to skip pairing tomorrow\n  * This is valid until matches go out at 04:00 UTC\n* `unskip tomorrow` to undo skipping tomorrow\n* `status` to show your current schedule, skip status, and name\n* `add-review {review_content}` to share a publicly viewable review about Pairing Bot\n* `unsubscribe` to stop getting matched entirely\n\nIf you've found a bug, please [submit an issue on github](https://github.com/thwidge/pairing-bot/issues)!"
 const subscribeMessage string = "Yay! You're now subscribed to Pairing Bot!\nCurrently, I'm set to find pair programming partners for you on **Mondays**, **Tuesdays**, **Wednesdays**, **Thursdays**, and **Fridays**.\nYou can customize your schedule any time with `schedule` :)"
 const unsubscribeMessage string = "You're unsubscribed!\nI won't find pairing partners for you unless you `subscribe`.\n\nBe well :)"
 const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
@@ -167,7 +167,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		}
 
 		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
-	case "review":
+	case "add-review":
 		reviewContent := cmdArgs[0]
 
 		currentTimestamp := time.Now().Unix()

--- a/main.go
+++ b/main.go
@@ -48,6 +48,12 @@ func main() {
 	}
 	defer pc.Close()
 
+	revc, err := firestore.NewClient(ctx, projectId)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer revc.Close()
+
 	rdb := &FirestoreRecurserDB{
 		client: rc,
 	}
@@ -62,6 +68,10 @@ func main() {
 
 	pdb := &FirestorePairingsDB{
 		client: pc,
+	}
+
+	revdb := &FirestoreReviewDB{
+		client: revc,
 	}
 
 	ur := &zulipUserRequest{}
@@ -84,6 +94,7 @@ func main() {
 		un:    un,
 		sm:    sm,
 		rcapi: rcapi,
+		revdb: revdb,
 	}
 
 	http.HandleFunc("/", http.NotFound)           // will this handle anything that's not defined?

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -213,8 +213,6 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 
 	emailsOfPeopleAtRc := pl.rcapi.getCurrentlyActiveEmails(accessToken)
 
-	log.Println("These are the emails of people currently at rc: ", emailsOfPeopleAtRc)
-
 	for i := 0; i < len(recursersList); i++ {
 
 		recurser := recursersList[i]

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -259,13 +259,13 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	pl.pdb.SetNumPairings(ctx, "monday", 5)
+
 	numPairings, err := pl.pdb.GetTotalPairingsDuringLastWeek(ctx)
 
 	if err != nil {
 		log.Println("Total Pairings: ", numPairings)
 	}
-
-	pl.pdb.SetNumPairings(ctx, "monday", 5)
 }
 
 /*

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -299,9 +299,9 @@ func getCheckinMessage(numPairings int, numRecursers int) string {
 		"```Bash\n" +
 			"=> Initializing the Pairing Bot process\n" +
 			"######################################################################## 100%%\n" +
-			"=> Loading recent data for Pairing Bot Usage\n" +
+			"=> Loading Pairing Bot Usage Statistics\n" +
 			"######################################################################## 100%%\n" +
-			"=> Teaching Pairing Bot how to boop beep boop for it is a strange loop\n" +
+			"=> Teaching Pairing Bot how to boop beep boop as it is a strange loop\n" +
 			"######################################################################## 00110001 00110000 00110000 00100101\n\n" +
 			"``` \n\n\n" +
 			"**%s Checkin**\n\n" +

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -88,14 +88,14 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	log.Printf("The user: %s issued the following request to Pairing Bot: %s", userData.userEmail, pl.ur.getCommandString())
+
 	// you *should* be able to throw any string at this thing and get back a valid command for dispatch()
 	// if there are no commad arguments, cmdArgs will be nil
 	cmd, cmdArgs, err := pl.ur.sanitizeUserInput()
 	if err != nil {
 		log.Println(err)
 	}
-
-	log.Printf("The user: %s issued the following request to Pairing Bot: %s", userData.userEmail, cmd)
 
 	// the tofu and potatoes right here y'all
 	response, err := dispatch(ctx, pl, cmd, cmdArgs, userData.userID, userData.userEmail, userData.userName)
@@ -263,7 +263,7 @@ func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
 	numPairings, err := pl.pdb.GetTotalPairingsDuringLastWeek(ctx)
 
 	if err != nil {
-		log.Println("Total Pairings: ", numPairings)
+		log.Println("Unable to get the total number of pairings durig the last week: : ", err)
 	}
 
 	recursersList, err := pl.rdb.GetAllUsers(ctx)

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -293,7 +293,7 @@ func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
 
 func getCheckinMessage(numPairings int, numRecursers int, review string) string {
 	today := time.Now()
-	todayFormatted := today.Format("January 1, 2006")
+	todayFormatted := today.Format("January 2, 2006")
 
 	message :=
 		"```Bash\n" +

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -181,8 +180,8 @@ func (pl *PairingLogic) match(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Pairing Bot paired up %d recursers today", numRecursersPairedUp)
 
-	dayOfWeek := strings.ToLower(time.Now().Weekday().String())
-	pl.pdb.SetNumPairings(ctx, dayOfWeek, numRecursersPairedUp)
+	timestamp := time.Now().Unix()
+	pl.pdb.SetNumPairings(ctx, int(timestamp), numRecursersPairedUp)
 }
 
 //Unsubscribe people from Pairing Bot when their batch is over. They're always welcome to re-subscribe manually!

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -23,6 +23,7 @@ const ownerID = "215391"
 type PairingLogic struct {
 	rdb   RecurserDB
 	adb   APIAuthDB
+	pdb   PairingsDB
 	ur    userRequest
 	un    userNotification
 	sm    streamMessage
@@ -253,6 +254,18 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		}
 
 	}
+}
+
+func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	numPairings, err := pl.pdb.GetTotalPairingsDuringLastWeek(ctx)
+
+	if err != nil {
+		log.Println("Total Pairings: ", numPairings)
+	}
+
+	pl.pdb.SetNumPairings(ctx, "monday", 5)
 }
 
 /*

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -22,8 +22,11 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		"schedule",
 		"skip",
 		"unskip",
-		"status"}
+		"status",
+		"review",
+	}
 
+	//This also includes common abbreviations for the days of the week
 	var daysList = []string{
 		"monday",
 		"tuesday",
@@ -31,7 +34,19 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		"thursday",
 		"friday",
 		"saturday",
-		"sunday"}
+		"sunday",
+		"mon",
+		"tu",
+		"tue",
+		"tues",
+		"wed",
+		"th",
+		"thu",
+		"thur",
+		"thurs",
+		"fri",
+		"sat",
+		"sun"}
 
 	// convert the string to a slice
 	// after this, we have a value "cmd" of type []string
@@ -39,8 +54,8 @@ func parseCmd(cmdStr string) (string, []string, error) {
 	space := regexp.MustCompile(`\s+`)
 	cmdStr = space.ReplaceAllString(cmdStr, ` `)
 	cmdStr = strings.TrimSpace(cmdStr)
-	cmdStr = strings.ToLower(cmdStr)
-	cmd := strings.Split(cmdStr, ` `)
+	cmdStrLower := strings.ToLower(cmdStr)
+	cmd := strings.Split(cmdStrLower, ` `)
 
 	// Big validation logic -- hellooo darkness my old frieeend
 	switch {
@@ -51,7 +66,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 
 	// if there's a valid command and if there's no arguments
 	case contains(cmdList, cmd[0]) && len(cmd) == 1:
-		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" {
+		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" || cmd[0] == "review" {
 			err = &parsingErr{"the user issued a command without args, but it reqired args"}
 			return "help", nil, err
 		}
@@ -69,6 +84,11 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		case cmd[0] == "unskip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
 			err = &parsingErr{"the user issued UNSKIP with malformed arguments"}
 			return "help", nil, err
+		case cmd[0] == "review":
+			//We manually split the input cmdStr here since the above code converts it to lower case
+			//and we want to presever the user's original formatting/casing
+			reviewArgs := strings.SplitN(cmdStr, " ", 2)
+			return "review", []string{reviewArgs[1]}, err
 		case cmd[0] == "schedule":
 			for _, v := range cmd[1:] {
 				if !contains(daysList, v) {

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -14,6 +15,8 @@ func (e parsingErr) Error() string {
 }
 
 func parseCmd(cmdStr string) (string, []string, error) {
+	log.Println("The cmdStr is: ", cmdStr)
+
 	var err error
 	var cmdList = []string{
 		"subscribe",
@@ -66,7 +69,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 
 	// if there's a valid command and if there's no arguments
 	case contains(cmdList, cmd[0]) && len(cmd) == 1:
-		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" || cmd[0] == "review" {
+		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" || cmd[0] == "add-review" {
 			err = &parsingErr{"the user issued a command without args, but it reqired args"}
 			return "help", nil, err
 		}
@@ -88,7 +91,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 			//We manually split the input cmdStr here since the above code converts it to lower case
 			//and we want to presever the user's original formatting/casing
 			reviewArgs := strings.SplitN(cmdStr, " ", 2)
-			return "review", []string{reviewArgs[1]}, err
+			return "add-review", []string{reviewArgs[1]}, err
 		case cmd[0] == "schedule":
 			for _, v := range cmd[1:] {
 				if !contains(daysList, v) {

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -23,7 +23,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		"skip",
 		"unskip",
 		"status",
-		"review",
+		"add-review",
 	}
 
 	//This also includes common abbreviations for the days of the week
@@ -84,7 +84,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		case cmd[0] == "unskip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
 			err = &parsingErr{"the user issued UNSKIP with malformed arguments"}
 			return "help", nil, err
-		case cmd[0] == "review":
+		case cmd[0] == "add-review":
 			//We manually split the input cmdStr here since the above code converts it to lower case
 			//and we want to presever the user's original formatting/casing
 			reviewArgs := strings.SplitN(cmdStr, " ", 2)


### PR DESCRIPTION
## What is the change? 

This PR adds the ability for Pairing Bot to post weekly checkins. These checkins will consist of 3 parts


1) How many recursers are currently subscribed to pairing bot.
2) The number of matches that pairing bot facilitated in the past week
3) A randomly selected review of pairing bot. [I still need to implement the ability for people to share feedback about pairing bot]

## Why are we making the change? 

Through speaking with Recursers it seems like some of them hear about Pairing Bot during the first week but then forget to sign up. I think it would help to gently remind people about Pairing Bot and show them how it helps other people through these weekly checkins. 